### PR TITLE
Limits concurrency on save

### DIFF
--- a/src/save.js
+++ b/src/save.js
@@ -10,7 +10,7 @@ const writeFile$ = Observable.bindNodeCallback(writeFile);
 const createSave = filePath => event$ => {
   if (!isString(filePath)) return event$;
 
-  return event$.delayWhen(event => {
+  return event$.map(event => {
     debug(`saving ${filePath}`);
     return writeFile$(
       filePath,
@@ -18,8 +18,8 @@ const createSave = filePath => event$ => {
       {encoding: 'UTF8'}
     ).do(() =>
       debug(`saved ${filePath}`)
-    );
-  });
+    ).mapTo(event);
+  }).concatAll();
 };
 
 export default createSave;


### PR DESCRIPTION
Problème avec l'opérateur [`delayWhen`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-delayWhen) qui ne correspond pas à notre use case. Il fallait utiliser [`concatAll`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-concatAll) qui permet de garder l'ordre.

Testé en local. Le `tmp.json` se met bien a jour.